### PR TITLE
feat: add oracle connect sidecar

### DIFF
--- a/pystarport/cluster.py
+++ b/pystarport/cluster.py
@@ -1325,6 +1325,20 @@ def supervisord_ini(cmd, validators, chain_id, start_flags=""):
             command=f"{cmd} start --home . {start_flags}",
             stdout_logfile=f"{directory}.log",
         )
+
+        oracle_config = node["app-config"].get("oracle", {})
+        if oracle_config.get("enabled"):
+            oracle_port = ports.oracle_port(node["base_port"])
+            grpc_address = node["app-config"].get("grpc", {}).get("address", "")
+            grpc_port = grpc_address.split(":")[1] if ":" in grpc_address else ports.grpc_port(node["base_port"])
+            oracle_section = f"program:{chain_id}-node{i}-oracle"
+            ini[oracle_section] = dict(
+                COMMON_PROG_OPTIONS,
+                directory=directory,
+                command=f"connect --market-map-endpoint=localhost:{grpc_port} --port {oracle_port}",
+                stdout_logfile=f"{directory}-oracle.log",
+            )
+
     return ini
 
 
@@ -1425,6 +1439,10 @@ def edit_app_cfg(path, base_port, app_config):
         },
         "grpc": {
             "address": "127.0.0.1:%d" % ports.grpc_port(base_port),
+        },
+        "oracle": {
+            "enabled": False,
+            "oracle_address": "127.0.0.1:%d" % ports.oracle_port(base_port),
         },
         "pruning": "nothing",
         "state-sync": {

--- a/pystarport/ports.py
+++ b/pystarport/ports.py
@@ -32,3 +32,7 @@ def rpc_port(base_port):
 
 def grpc_web_port(base_port):
     return base_port + 8
+
+
+def oracle_port(base_port):
+    return base_port + 9


### PR DESCRIPTION
```
  validators:  # genesis validators
    - coins: 1000000uom
      app-config:
        grpc:
          address: "0.0.0.0:9090"
        oracle:
          enabled: true
```
it will also create oracle connect sidecar daemon along with node daemon
```
[program:mantra-canary-net-1-node0]
autostart = true
autorestart = true
redirect_stderr = true
startsecs = 3
directory = %(here)s/node0
command = mantrachaind start --home . 
stdout_logfile = %(here)s/node0.log

[program:mantra-canary-net-1-node0-oracle]
autostart = true
autorestart = true
redirect_stderr = true
startsecs = 3
directory = %(here)s/node0
command = connect --market-map-endpoint=localhost:9090 --port 26659
stdout_logfile = %(here)s/node0-oracle.log
```

`pystarport start` will run both node and connect sidecar and match the port automatically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic configuration for oracle services in cluster management.
	- Added a new function to calculate the oracle port based on the base port.

- **Bug Fixes**
	- Updated default settings for oracle configuration to enhance deployment flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->