### PR TITLE
Problem: tendermint subcommand is deprecated

### DIFF
--- a/pystarport/cosmoscli.py
+++ b/pystarport/cosmoscli.py
@@ -102,8 +102,8 @@ class CosmosCLI:
         self.has_icaauth_subcommand = self.raw.prob_icaauth_subcommand()
 
     def node_id(self):
-        "get tendermint node id"
-        output = self.raw("tendermint", "show-node-id", home=self.data_dir)
+        "get comet node id"
+        output = self.raw("comet", "show-node-id", home=self.data_dir)
         return output.decode().strip()
 
     def delete_account(self, name):
@@ -716,7 +716,7 @@ class CosmosCLI:
         if "pubkey" not in options:
             pubkey = (
                 self.raw(
-                    "tendermint",
+                    "comet",
                     "show-validator",
                     home=self.data_dir,
                 )
@@ -762,7 +762,7 @@ class CosmosCLI:
         create the node with create_node before call this"""
         pubkey = (
             self.raw(
-                "tendermint",
+                "comet",
                 "show-validator",
                 home=self.data_dir,
             )


### PR DESCRIPTION
Solution:
- change to comet/cometbft

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Replaced Tendermint CLI usage with Comet CLI for node ID retrieval and validator public key detection within validator creation flows. No changes to user-facing interfaces or workflows.
- Bug Fixes
  - Improved compatibility with Comet-based nodes and networks, reducing errors when the Tendermint CLI is unavailable and ensuring reliable node ID and validator key retrieval during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->