### PR TITLE
Problem: unix domain sockets exceeds maximum path length on mac

### DIFF
--- a/pystarport/__init__.py
+++ b/pystarport/__init__.py
@@ -1,6 +1,11 @@
 import os
 import sys
+import tempfile
 from pathlib import Path
+
+if not os.environ.get("TMPDIR", "").startswith("/tmp"):
+    os.environ["TMPDIR"] = "/tmp"
+    tempfile.tempdir = "/tmp"
 
 proto_folder = Path(os.path.abspath(__file__)).parent.joinpath("proto_python")
 sys.path.append(str(proto_folder))

--- a/pystarport/cluster.py
+++ b/pystarport/cluster.py
@@ -1445,6 +1445,11 @@ def supervisord_ini(cmd, validators, chain_id, start_flags="", cmd_flags=""):
 
 def supervisord_ini_group(chain_ids, is_hermes):
     directory = "%(here)s"
+    data_dir_hash = hashlib.md5(
+        os.path.abspath(directory.replace("%(here)s", ".")).encode()
+    ).hexdigest()[:8]
+    socket_path = f"/tmp/supervisor-{data_dir_hash}.sock"
+
     cfg = {
         "include": {
             "files": " ".join(
@@ -1462,8 +1467,8 @@ def supervisord_ini_group(chain_ids, is_hermes):
             "supervisor.rpcinterface_factory": "supervisor.rpcinterface:"
             "make_main_rpcinterface",
         },
-        "unix_http_server": {"file": f"{directory}/supervisor.sock"},
-        "supervisorctl": {"serverurl": f"unix://{directory}/supervisor.sock"},
+        "unix_http_server": {"file": socket_path},
+        "supervisorctl": {"serverurl": f"unix://{socket_path}"},
     }
     command = "hermes --config relayer.toml start"
     if not is_hermes:

--- a/pystarport/cluster.py
+++ b/pystarport/cluster.py
@@ -1445,11 +1445,6 @@ def supervisord_ini(cmd, validators, chain_id, start_flags="", cmd_flags=""):
 
 def supervisord_ini_group(chain_ids, is_hermes):
     directory = "%(here)s"
-    data_dir_hash = hashlib.md5(
-        os.path.abspath(directory.replace("%(here)s", ".")).encode()
-    ).hexdigest()[:8]
-    socket_path = f"/tmp/supervisor-{data_dir_hash}.sock"
-
     cfg = {
         "include": {
             "files": " ".join(
@@ -1467,8 +1462,8 @@ def supervisord_ini_group(chain_ids, is_hermes):
             "supervisor.rpcinterface_factory": "supervisor.rpcinterface:"
             "make_main_rpcinterface",
         },
-        "unix_http_server": {"file": socket_path},
-        "supervisorctl": {"serverurl": f"unix://{socket_path}"},
+        "unix_http_server": {"file": f"{directory}/supervisor.sock"},
+        "supervisorctl": {"serverurl": f"unix://{directory}/supervisor.sock"},
     }
     command = "hermes --config relayer.toml start"
     if not is_hermes:


### PR DESCRIPTION
use short hash of the full path for uniqueness to avoid
```
2025-11-14 13:07:02,165 INFO Included extra file "/private/var/folders/99/4yby6hc52bd9vy7psykpt2ph0000gn/T/pytest-of-mavis/pytest-2/evm0/evm-canary-net-1/tasks.ini" during parsing
Error: Cannot open an HTTP server: socket.error reported AF_UNIX path too long
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system environment configuration to ensure temporary directory handling is consistent across different system setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->